### PR TITLE
update ml-cnpg image to install deps

### DIFF
--- a/ml-cnpg/Dockerfile
+++ b/ml-cnpg/Dockerfile
@@ -5,20 +5,16 @@ WORKDIR /
 
 COPY requirements.txt .
 
+# Install dependencies for running pgml
 RUN set -eux;\
   apt-get update; \
   apt-get upgrade -y; \
   apt-get install -y \
-    curl \
-    lsb-release \
-    tzdata \
-    sudo \
-    cmake \
-    libclang-dev \
-    wget \
-    git \
-    gnupg \
-    lsb-release
+    libopenblas-base \
+  ; \
+  apt-get autoremove -y; \
+  apt-get clean; \
+	rm -rf /var/lib/apt/lists/*;
 
 # Trunk Install Needed Extensions
 RUN set -eux; \
@@ -27,19 +23,20 @@ RUN set -eux; \
   trunk install hstore_plpython3u; \
   trunk install jsonb_plpython3u; \
   trunk install ltree_plpython3u; \
-  trunk install pg_embedding
+  trunk install pg_embedding;
 
 # cache all extensions
 RUN set -eux; \
       cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
-      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir
+      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
 
 # Revert the postgres user to id 26
 RUN usermod -u 26 postgres
 USER 26
 
 # Install Python dependencies
+ENV PATH=/var/lib/postgresql/.local/bin:$PATH
 RUN set -eux; \
-  pip3 install -r requirements.txt
+  pip3 install -r requirements.txt;
 
 ENV TRANSFORMERS_CACHE=/var/lib/postgresql/data/tembo/huggingface


### PR DESCRIPTION
* Add runtime dependency of `libopenblas-base` for pgml to run.
* Remove already installed tools and unneeded build tools since we are not building pgml or pgvector.
* Add PATH for pip installed dependencies