### PR TITLE
Bump trunk to 0.9.2

### DIFF
--- a/tembo-pg-cnpg/Dockerfile
+++ b/tembo-pg-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.8.0
+ARG TRUNK_VER=0.9.2
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk


### PR DESCRIPTION
Not urgent, but trunk CLI 0.9.x has post installation output that could be helpful when users run tembo locally:
- https://tembo.io/docs/guides/tembo-cloud/run-tembo-locally/