### PR TITLE
Bump trunk CLI to 0.10.4

### DIFF
--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.10.3
+ARG TRUNK_VER=0.10.4
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk

--- a/tembo-pg-cnpg/Dockerfile
+++ b/tembo-pg-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.9.2
+ARG TRUNK_VER=0.10.4
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk


### PR DESCRIPTION
Bump trunk CLI to `0.10.4` in `standard-cnpg` and `tembo-pg-cnpg`.