### PR TITLE
Bump trunk to 0.10.5

### DIFF
--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.10.4
+ARG TRUNK_VER=0.10.5
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk

--- a/tembo-pg-cnpg/Dockerfile
+++ b/tembo-pg-cnpg/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.70-bookworm as builder
 
-ARG TRUNK_VER=0.10.4
+ARG TRUNK_VER=0.10.5
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL sparse 
 RUN cargo install --version $TRUNK_VER pg-trunk


### PR DESCRIPTION
Bump trunk to `0.10.5` in `standard-cnpg` and `tembo-pg-cnpg` 