### PR TITLE
Drop duckdb dependencies from image

### DIFF
--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -58,12 +58,6 @@ RUN curl -o instantclient-basiclite-linux.x64-19.20.0.0.0dbru.zip https://downlo
     rm -rf instantclient_19_20 && \
     rm instantclient-basiclite-linux.x64-19.20.0.0.0dbru.zip
 
-# Install duckdb libs
-RUN wget https://github.com/duckdb/duckdb/releases/download/v0.8.1/libduckdb-linux-amd64.zip && \
-    unzip libduckdb-linux-amd64.zip && \
-    cp libduckdb.so /usr/lib/x86_64-linux-gnu/ && \
-    rm -rf libduckdb-linux-amd64.zip libduckdb.so
-
 # Install barman-cloud
 RUN set -xe; \
 	apt-get update; \


### PR DESCRIPTION
This was added months ago as part of an experiment. Dropping this dependency installation from image.