### PR TITLE
Add libbson-dev to standard-cnpg

### DIFF
--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -44,6 +44,7 @@ RUN set -eux; \
           openjdk-11-jdk \
           libaio1 \
           wget \
+          libbson-dev \
       ; \
       apt-get autoremove -y; \
       apt-get clean -y; \


### PR DESCRIPTION
`libbson-dev` is required for https://pgt.dev/extensions/postgresbson. Adding to `standard-cnpg` image.