### PR TITLE
Bump `standard-cnpg` image in ml and dw

### DIFF
--- a/dw-cnpg/Dockerfile
+++ b/dw-cnpg/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb
+FROM quay.io/tembo/standard-cnpg:15.3.0-1-795fc99
 USER root
 
 WORKDIR /

--- a/ml-cnpg/Dockerfile
+++ b/ml-cnpg/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/tembo/standard-cnpg:15.3.0-1-1096aeb
+FROM quay.io/tembo/standard-cnpg:15.3.0-1-795fc99
 USER root
 
 ARG PGML_VERSION=2.7.1


### PR DESCRIPTION
Bump `standard-cnpg` image in ML and DW images to `15.3.0-1-795fc99`

Related change in `standard-cnpg` image:
- https://github.com/tembo-io/tembo-images/pull/45