### PR TITLE
Add `libgsl-dev` to standard-cnpg

### DIFF
--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -1,7 +1,7 @@
 ARG PG_VERSION=15
 ARG TAG=latest
 
-FROM rust:1.70-bookworm as builder
+FROM rust:1.74-bookworm as builder
 
 ARG TRUNK_VER=0.12.19
 

--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -49,6 +49,7 @@ RUN set -eux; \
           libaio1 \
           wget \
           libbson-dev \
+          libgsl-dev \
       ; \
       apt-get autoremove -y; \
       apt-get clean -y; \


### PR DESCRIPTION
Add `libgsl-dev` to standard-cnpg image. Related to:
- https://github.com/tembo-io/trunk/pull/659