### PR TITLE
Base analytics on standard-cnpg:latest

### DIFF
--- a/analytics-cnpg/Dockerfile
+++ b/analytics-cnpg/Dockerfile
@@ -1,5 +1,5 @@
 ARG PG_VERSION=16
-ARG TAG=86080de
+ARG TAG=latest
 
 FROM quay.io/tembo/standard-cnpg:${PG_VERSION}-${TAG} AS build
 USER root

--- a/geo-cnpg/Dockerfile
+++ b/geo-cnpg/Dockerfile
@@ -47,8 +47,9 @@ RUN /usr/bin/trunk install postgis --version 3.5.0 \
 
 # cache all extensions
 RUN set -eux; \
-      cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
-      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
+    ldconfig; \
+    cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
+    cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV XDG_CACHE_HOME=/var/lib/postgresql/data/tembo/.cache

--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -120,6 +120,7 @@ RUN set -eux; \
     ln -s libduckdb.so "libduckdb.${DUCKDB_VERSION}.so"; \
     mv libduckdb*.so /usr/local/lib/; \
     rm -rf pg_duckdb*; \
+    ldconfig; \
     # Install auto_explain and pg_stat_statements.
     /usr/bin/trunk install auto_explain; \
     /usr/bin/trunk install pg_stat_statements; \


### PR DESCRIPTION
In order to have updated dependencies (and to use the same tag as the other images).

Also run `ldconfig` after installing DSOs so that the system cache is updated to find them.