### PR TITLE
Upgrade to 17.3, 16.7, 15.11, and 14.16

### DIFF
--- a/.github/workflows/build_tembo_pg_slim.yaml
+++ b/.github/workflows/build_tembo_pg_slim.yaml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   pre-build:
+    name: ✨ Pre Build
     runs-on: ubuntu-latest
     outputs:
       short_sha: ${{ steps.versions.outputs.SHORT_SHA }}
@@ -41,10 +42,11 @@ jobs:
           echo "BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
       - name: Append PostgreSQL configurations to matrix
         id: append_pg_configs
+        env:
+          # Update with the latest releases.
+          TAGS: '["17_3", "16_7", "15_11", "14_16"]'
         run: |
-          PG_CONFIGS='[{"pg_version": "14"}, {"pg_version": "15"}, {"pg_version": "16"}, {"pg_version": "17"}]'
-          MODIFIED_MATRIX=$(echo $PG_CONFIGS | jq -c '{include: .}')
-          echo "build_matrix=$MODIFIED_MATRIX" >> $GITHUB_OUTPUT
+          printf "build_matrix=%s" $(jq -cn --argjson pg "$TAGS" '$pg | {include: map({pg_tag: ., pg_version: scan("^\\d+")})}') >> $GITHUB_OUTPUT
       - name: Determine which tags to publish
         id: tags_list
         run: |
@@ -89,6 +91,7 @@ jobs:
           echo "Tags: ${{ steps.tags.outputs.tags }}"
 
   tembo-pg-slim-build:
+    name: 🧱 tembo-pg-slim 🐘 ${{ matrix.pg_version }}
     needs: pre-build
     permissions:
       id-token: write
@@ -107,7 +110,7 @@ jobs:
       - name: Build Docker images based on conditions
         run: |
           IMAGE_NAME=$CONTAINER_NAME:${{ matrix.pg_version }}
-          docker build ./$CONTAINER_NAME --build-arg PG_VERSION=${{ matrix.pg_version }} -t $IMAGE_NAME
+          docker build ./$CONTAINER_NAME --build-arg PG_VERSION=${{ matrix.pg_version }} --build-arg PG_TAG=REL_${{ matrix.pg_tag }} -t $IMAGE_NAME
         shell: bash
       - name: Login to Tembo Quay
         uses: docker/login-action@v2
@@ -127,6 +130,7 @@ jobs:
           done
 
   standard-cnpg-build:
+    name: 📐 standard-cnpg 🐘 ${{ matrix.pg_version }}
     needs: [pre-build, tembo-pg-slim-build]
     permissions:
       id-token: write
@@ -184,6 +188,7 @@ jobs:
           done
 
   ml-cnpg-build:
+    name: 🤖 ml-cnpg 🐘 ${{ matrix.pg_version }}
     needs: [pre-build, standard-cnpg-build]
     permissions:
       id-token: write
@@ -253,6 +258,7 @@ jobs:
           done
 
   dw-cnpg-build:
+    name: 🏢 dw-cnpg 🐘 ${{ matrix.pg_version }}
     needs: [pre-build, standard-cnpg-build]
     permissions:
       id-token: write
@@ -316,6 +322,7 @@ jobs:
           done
 
   geo-cnpg-build:
+    name: 🌍 geo-cnpg 🐘 ${{ matrix.pg_version }}
     needs: [pre-build, standard-cnpg-build]
     permissions:
       id-token: write
@@ -373,6 +380,7 @@ jobs:
           done
 
   analytics-cnpg-build:
+    name: 📊 analytics-cnpg 🐘 ${{ matrix.pg_version }}
     needs: [pre-build, standard-cnpg-build]
     permissions:
       id-token: write
@@ -437,6 +445,7 @@ jobs:
           done
 
   tembo-pg-cnpg-build:
+    name: ☁️ tembo-pg-cnpg 🐘 ${{ matrix.pg_version }}
     needs: [pre-build, tembo-pg-slim-build]
     permissions:
       id-token: write

--- a/tembo-pg-slim/Dockerfile
+++ b/tembo-pg-slim/Dockerfile
@@ -6,12 +6,13 @@ ARG ALTDIR=/var/lib/postgresql/data/tembo
 ENV TZ=Etc/UTC
 ENV PGDATA /var/lib/postgresql/data
 ARG PG_VERSION 15
+ARG PG_TAG REL_15_11
 ENV PATH $PATH:/usr/lib/postgresql/$PG_VERSION/bin
 
 # Get latest package updates
 RUN set -eux; \
       apt-get update; \
-      apt-get upgrade -y 
+      apt-get upgrade -y
 
 # Set the postgres user's permissions
 RUN set -eux; \
@@ -19,7 +20,7 @@ RUN set -eux; \
       useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
       mkdir -p /var/lib/postgresql; \
       chown -R postgres:postgres /var/lib/postgresql; \
-      apt-get update; apt-get install -y curl ca-certificates gnupg lsb-release lbzip2 git
+      apt-get install -y curl ca-certificates gnupg lsb-release lbzip2 git
 
 STOPSIGNAL SIGINT
 
@@ -33,12 +34,6 @@ RUN set -eux; \
 ENV LANG en_US.utf8
 
 RUN mkdir /docker-entrypoint-initdb.d
-
-RUN git clone https://github.com/postgres/postgres.git && \
-    cd postgres && \
-    PG_RELEASE=$(git tag | grep '^REL_'${PG_VERSION}'_' | grep -vE 'RC|BETA' | sort -V | tail -1 | sed 's/REL_//') && \
-    echo $PG_RELEASE && \
-    git checkout REL_$PG_RELEASE
 
 RUN set -eux; \
       apt-get update && apt-get install -y \
@@ -74,11 +69,11 @@ RUN set -eux; \
       apt-get clean -y; \
       rm -rf /var/lib/apt/lists/*
 
-WORKDIR postgres
-
 ENV CFLAGS "-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer"
 ENV LDFLAGS "-Wl,-z,relro -Wl,-z,now"
-RUN ./configure --prefix=/usr/lib/postgresql/${PG_VERSION} \
+RUN git clone --depth 1 --branch ${PG_TAG} https://git.postgresql.org/git/postgresql.git; \
+    cd postgresql; \
+    ./configure --prefix=/usr/lib/postgresql/${PG_VERSION} \
         --datarootdir=${ALTDIR} \
         --libdir=${ALTDIR}/${PG_VERSION}/lib \
         --with-perl \
@@ -102,10 +97,9 @@ RUN ./configure --prefix=/usr/lib/postgresql/${PG_VERSION} \
         --with-lz4 \
         --with-zstd \
         --with-systemd \
-        --with-selinux
-
-RUN make -j$(nproc)
-RUN make install
+        --with-selinux; \
+        make -j$(nproc); \
+        make install
 
 # Remove libpq-dev provided from Ubuntu repos and set the newly-compiled one to system path
 RUN set -eux; \
@@ -117,7 +111,7 @@ RUN echo "${ALTDIR}/${PG_VERSION}/lib" > /etc/ld.so.conf.d/postgres.conf && \
     ldconfig
 
 WORKDIR /
-RUN rm -rf /postgres
+RUN rm -rf /postgresql
 
 RUN mkdir -p /var/run/postgresql && chmod 775 /var/run/postgresql
 RUN mkdir -p /usr/share/postgresql/${PG_MAJOR}/extension && chmod 775 /usr/share/postgresql/${PG_MAJOR}/extension

--- a/tembo-pg-slim/README.md
+++ b/tembo-pg-slim/README.md
@@ -1,6 +1,7 @@
 # Postgres Docker Base Image
 
-Contains a Dockerfile with Postgres 15.3, no extensions and no additional tools.
+Contains a Dockerfile that builds PostgreSQL from source with no extensions
+and no additional tools.
 
 ## Versioning
 


### PR DESCRIPTION
Refactor the generation of the postgres version matrix in `.github/workflows/build_tembo_pg_slim.yaml` to include both the major version and a full version with an underscore as used in Postgres tags. Pass it to the `tembo-pg-slim/Dockerfile` as `PG_TAG` and use it to perform a shallow clone of just the release tag. This way, any time there are new versions, we can just edit the `TAGS` environment variable to trigger an efficient rebuild with the latest version for all images.