### PR TITLE
Add ld.so.conf.d/tembo.conf to base image (#91)

### DIFF
--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -117,8 +117,7 @@ RUN set -eux; \
     # Grab libduckdb from the pg_duckdb trunk package
     curl -LO https://cdb-plat-use1-prod-pgtrunkio.s3.amazonaws.com/extensions/pg_duckdb/pg_duckdb-pg${PG_VERSION}-${PG_DUCKDB_VERSION}.tar.gz; \
     tar zxvf pg_duckdb-pg${PG_VERSION}-${PG_DUCKDB_VERSION}.tar.gz libduckdb.so; \
-    ln -s libduckdb.so "libduckdb.${DUCKDB_VERSION}.so"; \
-    mv libduckdb*.so /usr/local/lib/; \
+    mv libduckdb.so /usr/local/lib/libduckdb.so.${DUCKDB_VERSION}; \
     rm -rf pg_duckdb*; \
     ldconfig; \
     # Install auto_explain and pg_stat_statements.

--- a/tembo-pg-slim/Dockerfile
+++ b/tembo-pg-slim/Dockerfile
@@ -107,7 +107,11 @@ RUN set -eux; \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
-RUN echo "${ALTDIR}/${PG_VERSION}/lib" > /etc/ld.so.conf.d/postgres.conf && \
+# Configure ldd to find additional shared libraries in `${ALTDIR}/lib` and
+# Postgres versioned libraries in `pg_config --pkglibdir`.
+RUN echo "${ALTDIR}/${PG_VERSION}/lib" > /etc/ld.so.conf.d/postgres.conf; \
+    echo "${ALTDIR}/lib" > /etc/ld.so.conf.d/tembo.conf; \
+    mkdir -p "${ALTDIR}/lib"; \
     ldconfig
 
 WORKDIR /


### PR DESCRIPTION
This will allow the persistence of shared libraries currently installed in non-persistent locations like `/usr/local/lib`. None included so far; see TEM-3045 for details. Resolves TEM-3043.