### PR TITLE
Cease copying `pkglibdir` (#95)

### DIFF
--- a/geo-cnpg/Dockerfile
+++ b/geo-cnpg/Dockerfile
@@ -48,7 +48,6 @@ RUN /usr/bin/trunk install postgis --version 3.5.0 \
 # cache all extensions
 RUN set -eux; \
     ldconfig; \
-    cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
     cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH

--- a/ml-cnpg/Dockerfile
+++ b/ml-cnpg/Dockerfile
@@ -20,9 +20,7 @@ RUN set -eux; \
   trunk install ltree_plpython3u;
 
 # cache all extensions
-RUN set -eux; \
-      cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
-      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
+RUN cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
 
 # Revert the postgres user to id 26
 RUN usermod -u 26 postgres

--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -124,8 +124,7 @@ RUN set -eux; \
     /usr/bin/trunk install auto_explain; \
     /usr/bin/trunk install pg_stat_statements; \
     # cache pg_stat_statements and auto_explain and pg_stat_kcache to temp directory
-    mkdir /tmp/pg_pkglibdir /tmp/pg_sharedir; \
-    cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
+    mkdir /tmp/pg_sharedir; \
     cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir
 
 # Revert the postgres user to id 26

--- a/tembo-pg-cnpg/Dockerfile
+++ b/tembo-pg-cnpg/Dockerfile
@@ -42,9 +42,7 @@ RUN trunk install auto_explain
 
 # cache pg_stat_statements and auto_explain and pg_stat_kcache to temp directory
 RUN set -eux; \
-	  mkdir /tmp/pg_pkglibdir; \
 	  mkdir /tmp/pg_sharedir; \
-      cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
       cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir
 
 # Revert the postgres user to id 26


### PR DESCRIPTION
The `pkglibdir` is currently a subdirectory of `sharedir`, so copying it is redundant. It was deprecated in tembo-io/tembo@a377faa10.