### PR TITLE
Create new Postgres image and bake pipeline

### DIFF
--- a/.github/workflows/bake.yaml
+++ b/.github/workflows/bake.yaml
@@ -1,0 +1,100 @@
+name: 🧁 Bake Postgres Images
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/bake.yaml
+      - "[dD]ocker*"
+      - CONTAINER_README.md
+      - manifest\.js
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/bake.yaml
+      - "[dD]ocker*"
+      - CONTAINER_README.md
+      - manifest\.js
+  schedule:
+    - cron: 0 8 * * 1
+
+jobs:
+  bake:
+    name: 🐘 ${{ matrix.pg }} ${{ matrix.os[0] }} ${{ matrix.os[1] }} ${{ matrix.arch[0] }} ${{ matrix.arch[1] }}
+    # https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
+    runs-on: ubuntu-${{ matrix.arch[1] == 'arm64' && '24.04-arm' || 'latest' }}
+    strategy:
+      matrix:
+        pg: ["17.4", "16.8", "15.12", "14.17"]
+        os: [["🐿️", "noble"], ["🪼", "jammy"] ]
+        arch: [["🦾", "arm64"], ["🤖", "amd64"]]
+    outputs:
+      images: ${{ steps.meta.outputs.json }}
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with: { tool-cache: false }
+      - name: Login to Docker Hub # required for un-throttled pulls
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER_TEMBO }}
+          password: ${{ secrets.QUAY_PASSWORD_TEMBO }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build the Images
+        id: build
+        uses: docker/bake-action@v6
+        env:
+          registry: quay.io/tembo
+          revision: ${{ github.sha }}
+          arch: ${{ matrix.arch[1] }}
+          os: ${{ matrix.os[1] }}
+          pg: ${{ matrix.pg }}
+        with:
+          pull: true
+          # Set to build only the current arch, to push only SHAs, and no
+          # tags. Required for the manifest step to build and push a
+          # multi-platform manifest.
+          set: |
+            *.platform=linux/${{ matrix.arch[1] }}
+            *.output=type=${{ github.ref_name == 'main' && 'image,push-by-digest=true,push=true' || 'cacheonly' }}
+            *.tags=quay.io/tembo/postgres
+      - name: Save Metadata
+        run: echo '${{ steps.build.outputs.metadata }}' > build-${{ matrix.arch[1] }}-${{ matrix.os[1] }}-${{ matrix.pg }}.json
+      - name: Upload Metadata
+        uses: actions/upload-artifact@v4
+        with:
+          path: build-${{ matrix.arch[1] }}-${{ matrix.os[1] }}-${{ matrix.pg }}.json
+          name: build-${{ matrix.arch[1] }}-${{ matrix.os[1] }}-${{ matrix.pg }}
+          overwrite: true
+          if-no-files-found: error
+          retention-days: 1
+  manifest:
+    name: 📃 Push Manifests
+    runs-on: ubuntu-latest
+    needs: bake
+    if: ${{ github.ref_name == 'main' }}
+    env:
+      REGISTRY: quay.io/tembo
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Download Metadata
+        uses: actions/download-artifact@v4
+        with: { pattern: build-*, merge-multiple: true }
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER_TEMBO }}
+          password: ${{ secrets.QUAY_PASSWORD_TEMBO }}
+      - name: Build and Push Manifests
+        run: node manifest.js build-*.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+target/
+Cargo.lock
+*.iml
+**/*.rs.bk
+.vscode/
+vendor/

--- a/CONTAINER_README.md
+++ b/CONTAINER_README.md
@@ -1,0 +1,39 @@
+Tembo PostgreSQL
+================
+
+You have shelled into an instance of Tembo Postgres. All of persistent files
+live here in `/var/lib/postgresql`. Here's a description of subdirectories and
+their purposes:
+
+*   `data`: The directory in which the Docker entrypoint initializes
+    a cluster and which [CloudNativePG] mounts as a persistent volume.
+*   `data/pgdata`: The data directory initialized by the Docker entrypoint and
+    [CloudNativePG].
+*   `tembo`: The directory that [Tembo Cloud] mounts as the persistent volume
+    for the database and extensions.
+*   `tembo/pgdata`: The data directory initialized by [Tembo Cloud].
+*   `tembo/share`: The directory for architecture-independent support files
+    used by Postgres. This is the directory used by `pg_config --sharedir` to
+    install non-binary extension files. Its files are copied from
+    `/tmp/pg_sharedir` when the Tembo operator initializes the volume.
+*   `tembo/${PG_MAJOR}/lib`: A directory for extension shared library files
+    compiled for a specific major version of Postgres.
+*   `tembo/${OS_NAME}/lib`: A directory for OS shared library files.
+*   `tembo/${OS_NAME}/etc`: The home of the library loading cache, updated
+    by `ldconfig` when new files are installed into
+    `tembo/${OS_NAME}/lib`. The canonical cache file, `/etc/ld.so.cache`,
+    is a symlink into this directory.
+
+
+Other useful locations around the system:
+
+*   `/usr/lib/postgresql`: The base directory for Postgres itself.
+*   `/usr/local/bin/docker-entrypoint.sh`: The docker entrypoint script, which
+    initializes and starts a Postgres cluster in `/var/lib/postgresql/data/pgdata`.
+*   `/etc/ld.so.conf.d/postgres.conf`: Configures the library loader to look
+    for library files in the Postgres library directory (`pg_config --libdir`).
+*   `/etc/ld.so.conf.d/tembo.conf`: Configures the library loader to look
+    for library files in `/var/lib/postgresql/tembo/${OS_NAME}/lib`.
+
+  [CloudNativePG]: https://cloudnative-pg.io
+  [Tembo Cloud]: https://tembo.io/docs/product/cloud/overview "Tembo Cloud Overview"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,174 @@
+# syntax=docker/dockerfile:1.7-labs
+ARG BASE
+ARG OS_NAME
+ARG PG_VERSION
+ARG PG_MAJOR=${PG_VERSION%%.*}
+ARG PG_PREFIX=/usr/lib/postgresql
+ARG PG_HOME=/var/lib/postgresql
+ARG CNPG_VOLUME=${PG_HOME}/data
+
+# Tembo-specific volume mount, sharedir, dynamic_library_path target, and
+# System LLD dir.
+ARG TEMBO_VOLUME=${PG_HOME}/tembo
+ARG TEMBO_SHARE_DIR=${TEMBO_VOLUME}/share
+ARG TEMBO_PG_LIB_DIR=${TEMBO_VOLUME}/${PG_MAJOR}/lib
+ARG TEMBO_LD_LIB_DIR=${TEMBO_VOLUME}/${OS_NAME}/lib
+ARG TEMBO_ETC_DIR=${TEMBO_VOLUME}/${OS_NAME}/etc
+
+##############################################################################
+# Build trunk.
+FROM rust:1.83-bookworm AS trunk
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+RUN cargo install pg-trunk
+
+##############################################################################
+# Build PostgreSQL.
+FROM ${BASE} AS build
+ARG PG_VERSION PG_PREFIX TEMBO_SHARE_DIR
+WORKDIR /work
+
+# Upgrade to the latest packages and install dependencies.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update; apt-get upgrade -y && apt-get install -y \
+    locales \
+    libreadline-dev \
+    zlib1g-dev \
+    build-essential \
+    python3-dev \
+    tcl-dev \
+    libxslt1-dev \
+    libperl-dev \
+    libpam0g-dev \
+    libssl-dev \
+    xz-utils \
+    libnss-wrapper \
+    llvm \
+    clang \
+    icu-devtools \
+    pkg-config \
+    libgss-dev \
+    libkrb5-dev \
+    uuid-dev \
+    gettext \
+    liblz4-dev \
+    libsystemd-dev \
+    libselinux1-dev \
+    libzstd-dev \
+    flex \
+    bison
+
+# Download and unpack the PostgreSQL source.
+ADD https://ftp.postgresql.org/pub/source/v${PG_VERSION}/postgresql-${PG_VERSION}.tar.bz2 .
+RUN tar jxf postgresql-${PG_VERSION}.tar.bz2
+WORKDIR /work/postgresql-${PG_VERSION}
+
+# Compile and install PostgreSQL.
+RUN set -ex; \
+    ./configure \
+        CFLAGS="-g -O2 -fstack-protector-strong -Wformat -Werror=format-security -fno-omit-frame-pointer" \
+        LDFLAGS="-Wl,-z,relro -Wl,-z,now" \
+        --prefix="${PG_PREFIX}" \
+        --datarootdir="${TEMBO_SHARE_DIR}" \
+        --docdir="${PG_PREFIX}/doc" \
+        --htmldir="${PG_PREFIX}/html" \
+        --localedir="${PG_PREFIX}/locale" \
+        --mandir="${PG_PREFIX}/man" \
+        --with-perl \
+        --with-python \
+        --with-tcl \
+        --with-pam \
+        --with-libxml \
+        --with-libxslt \
+        --with-openssl \
+        --enable-nls \
+        --enable-thread-safety \
+        --enable-debug \
+        --with-uuid=e2fs \
+        --with-gnu-ld \
+        --with-gssapi \
+        --with-pgport=5432 \
+        --with-system-tzdata=/usr/share/zoneinfo \
+        --with-icu \
+        --with-llvm \
+        --with-lz4 \
+        --with-zstd \
+        --with-systemd \
+        --with-selinux; \
+    make -j$(nproc); \
+    make install; \
+    make -C contrib/auto_explain install; \
+    make -C contrib/pg_stat_statements install
+
+##############################################################################
+# Build the base image.
+FROM ${BASE} AS install
+ARG CNPG_VOLUME PACKAGES TEMBO_LD_LIB_DIR TEMBO_PG_LIB_DIR PG_PREFIX PG_HOME TEMBO_ETC_DIR
+
+# Copy the PostgreSQL files and trunk.
+COPY --link --from=build --parents /var/lib/./postgresql /var/lib/
+COPY --link --from=build --parents /usr/lib/./postgresql /usr/lib/
+COPY --link --from=trunk /usr/local/cargo/bin/trunk /usr/local/bin/trunk
+
+# Upgrade to the latest packages and install dependencies.
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y \
+    locales \
+    locales-all \
+    ssl-cert \
+    ca-certificates \
+    tzdata \
+    libssl3 \
+    libgssapi-krb5-2 \
+    libxml2 \
+    libxslt1.1 \
+    libreadline8 \
+    libtcl8.6 \
+    xz-utils \
+    libgss3 \
+    libkrb5-3 \
+    ${PACKAGES}
+
+# Clean up and finish configuration.
+ENV PATH=${PG_PREFIX}/bin:$PATH
+RUN set -xe; \
+    apt-get clean -y; \
+    # Set up en_US.UTF-8
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8; \
+    # Configure ldd to find additional shared libraries in sharedir and TEMBO_LD_LIB_DIR.
+    printf "%s\n" "$(pg_config --libdir)" > /etc/ld.so.conf.d/postgres.conf; \
+    printf "${TEMBO_LD_LIB_DIR}\n" > /etc/ld.so.conf.d/tembo.conf; \
+    # Create the OS LD dir, postgres lib dir, and standard CNPG volume dir. 
+    mkdir -p "${TEMBO_LD_LIB_DIR}" "${TEMBO_PG_LIB_DIR}" "${CNPG_VOLUME}"; \
+    rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/*; \
+    # Update the LD cache and symlink it into the volume directory.
+    ldconfig; \
+    mkdir -p "${TEMBO_ETC_DIR}"; \
+    mv /etc/ld.so.cache ${TEMBO_ETC_DIR}; \
+    ln -s ${TEMBO_ETC_DIR}/ld.so.cache /etc; \
+    # Stash away sharedir and etc so the Tembo operator can copy them back
+    # when it initializes the pod. (We should be able to do it during pod
+    # initialization without a temp copy: https://stackoverflow.com/a/72269316/79202)
+    cp -lr "$(pg_config --sharedir)" /tmp/pg_sharedir; \
+    cp -lr "${TEMBO_ETC_DIR}" /tmp/tembo_etcdir;
+
+# Add the README.
+COPY CONTAINER_README.md "${PG_HOME}/README.md"
+
+# Create the Postgres user and set its uid to what CNPG expects.
+RUN groupadd -r postgres --gid=999 && \
+	useradd -r -g postgres --uid=26 --home-dir=${PG_HOME} --shell=/bin/bash postgres && \
+    chown -R postgres:postgres ${PG_HOME};
+
+# Add the entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+
+##############################################################################
+# Build the postgres image as a single layer.
+FROM scratch AS postgres
+ARG PG_PREFIX PG_HOME
+
+COPY --link --from=INSTALL / /
+WORKDIR ${PG_HOME}
+ENV TZ=Etc/UTC LANG=en_US.utf8 PATH=${PG_PREFIX}/bin:$PATH
+USER 26
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,152 @@
+# Variables to be specified externally.
+variable "registry" {
+  default = "quay.io/tembo"
+  description = "The image registry."
+}
+
+variable "revision" {
+  default = ""
+  description = "The current Git commit SHA."
+}
+
+variable pg {
+  default = "17.4"
+  description = "Version of Postgres to build. Must be major.minor."
+}
+
+variable os {
+  default = latest_os
+  description = "OS to build, one of “noble” or “jammy”."
+  validation {
+    condition = contains(keys(os_spec), os)
+    error_message = "os must be one of ${join(", ", keys(os_spec))}"
+  }
+}
+
+variable arch {
+  default = ""
+  description = "CPU Architecture to build."
+  validation {
+    condition = contains(keys(arch_for), arch)
+    error_message = "arch must be one of ${join(", ", keys(arch_for))}"
+  }
+}
+
+# Internal variables.
+variable latest_os {
+  default = "noble"
+  description = "Defines the current latest OS name."
+}
+
+variable latest_pg {
+  default = "17"
+  description = "Defines the current latest PostgreSQL major version."
+}
+
+variable os_spec {
+  description = "Info about the base OS images. Update the config to support new releases."
+  default = {
+    noble = {
+      image = "quay.io/tembo/ubuntu:24.04",
+      digest = "72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782"
+      packages = "libicu74 libllvm19 libpython3.12 libperl5.38"
+    },
+    jammy = {
+      image = "quay.io/tembo/ubuntu:22.04",
+      digest = "ed1544e454989078f5dec1bfdabd8c5cc9c48e0705d07b678ab6ae3fb61952d2"
+      packages = "libicu70 libllvm15 libpython3.11 libperl5.34"
+    }
+  }
+}
+
+variable arch_for {
+  description = "Simple map of common `uname -m` architecture names to the canonical name."
+  default = {
+    amd64 = "amd64"
+    x86_64 = "amd64"
+    x64 = "amd64"
+    x86-64 = "amd64"
+    arm64 = "arm64"
+    aarch64 = "arm64"
+  }
+}
+
+# Values to use in the targets.
+now = timestamp()
+authors = "Tembo"
+url = "https://github.com/tembo-io/tembo-images"
+
+target "default" {
+  matrix = {}
+  platforms = ["linux/${arch_for[arch]}"]
+  dockerfile = "Dockerfile"
+  name = "postgres-${replace(pg, ".", "_")}-${arch_for[arch]}-${os}"
+  tags = tags(pg, os)
+  context = "."
+  target = "postgres"
+  args = {
+    PG_VERSION = "${pg}"
+    BASE = "${os_spec[os].image}@sha256:${os_spec[os].digest}"
+    OS_NAME = "${os}"
+    PACKAGES = "${os_spec[os].packages}"
+  }
+  annotations = [
+    "index,manifest:org.opencontainers.image.created=${now}",
+    "index,manifest:org.opencontainers.image.url=${url}",
+    "index,manifest:org.opencontainers.image.source=${url}",
+    "index,manifest:org.opencontainers.image.version=${pg}",
+    "index,manifest:org.opencontainers.image.revision=${revision}",
+    "index,manifest:org.opencontainers.image.vendor=${authors}",
+    "index,manifest:org.opencontainers.image.title=Tembo PostgreSQL ${pg}",
+    "index,manifest:org.opencontainers.image.description=PostgreSQL ${pg}",
+    "index,manifest:org.opencontainers.image.documentation=${url}",
+    "index,manifest:org.opencontainers.image.authors=${authors}",
+    "index,manifest:org.opencontainers.image.licenses=PostgreSQL",
+    "index,manifest:org.opencontainers.image.base.name=${os_spec[os].image}",
+    "index,manifest:org.opencontainers.image.base.digest=${os_spec[os].digest}",
+  ]
+  labels = {
+    "org.opencontainers.image.created" = "${now}",
+    "org.opencontainers.image.url" = "${url}",
+    "org.opencontainers.image.source" = "${url}",
+    "org.opencontainers.image.version" = "${pg}",
+    "org.opencontainers.image.revision" = "${pg}",
+    "org.opencontainers.image.vendor" = "${authors}",
+    "org.opencontainers.image.title" = "PostgreSQL ${pg}",
+    "org.opencontainers.image.description" = "PostgreSQL ${pg}",
+    "org.opencontainers.image.documentation" = "${url}",
+    "org.opencontainers.image.authors" = "${authors}",
+    "org.opencontainers.image.licenses" = "PostgreSQL"
+    "org.opencontainers.image.base.name" = "${os_spec[os].image}",
+    "org.opencontainers.image.base.digest" = "${os_spec[os].digest}",
+  }
+}
+
+# Returns the major of a PostgreSQL version. For example, returns `17` for
+# `17.4`.
+function major {
+  params = [ version ]
+  result = index(split(".",version), 0)
+}
+
+# Creates the tags for the Postgres image. If `os_name` is the same as
+# `latest_os`, it returns five tags, plus "latest" if `pg` is the same as
+# `latest_pg`. Otherwise it returns three. These are the standard tags, but we
+# don't actually use this configuration currently, because the build process
+# in .github/workflows/bake.yaml requires building amd64 and arm64 images
+# separately and pushing them by their SHAs and then joining them into
+# multi-platform images in manifest.js as a second step. But the pattern here
+# and in manifest.js should be the same.
+function tags {
+  params = [ pg, os_name ]
+  result = flatten([
+    os_name == latest_os ? flatten([
+      major(pg) == latest_pg ? ["${registry}/postgres:latest"] : [],
+      "${registry}/postgres:${major(pg)}",
+      "${registry}/postgres:${pg}",
+    ]) : [],
+    "${registry}/postgres:${major(pg)}-${os_name}",
+    "${registry}/postgres:${pg}-${os_name}",
+    "${registry}/postgres:${pg}-${os_name}-${formatdate("YYYYMMDDhhmm", now)}",
+  ])
+}

--- a/manifest.js
+++ b/manifest.js
@@ -1,0 +1,111 @@
+// To test locally:
+//
+// Set up a local registry on port 5001:
+//
+//     docker run -d -p 5001:5000 --restart=always --name registry registry:2
+//
+// Bake images separately for amd64 and arm64 and push them only by their
+// SHAs:
+//
+//     registry=localhost:5001 arch=amd64 pg=17.4 \
+//         docker buildx bake \
+//         --set '*.output=push-by-digest=true,type=image,push=true' \
+//         --set '*.tags=localhost:5001/postgres' \
+//         --metadata-file amd64.json
+//     registry=localhost:5001 arch=arm64 pg=17.4 \
+//         docker buildx bake \
+//         --set '*.output=push-by-digest=true,type=image,push=true' \
+//         --set '*.tags=localhost:5001/postgres' \
+//         --metadata-file arm64.json
+//
+// Run the script.
+//
+//     export REGISTRY=localhost:5001
+//     node manifest.js *.json
+//
+// Get a list of all the tags in the registry:
+//
+//     curl -s localhost:5001/v2/postgres/tags/list | jq
+
+const LATEST_OS="noble"
+const LATEST_PG=17
+
+const slurp = require("fs").readFileSync;
+
+if (process.argv.length < 3) {
+    console.log(`Usage: ${ process.argv[1] } BUILD_META_FILE [BUILD_META_FILE...]`)
+    process.exit(1)
+}
+
+// UTC Timestamp in YYYYMMDDhhmm format.
+const now = new Date().toISOString().slice(0, 16).replaceAll(/[T:-]/g, "")
+
+let images = {}
+
+for (let i = 2; i < process.argv.length; i++) {
+    const build_meta = JSON.parse(slurp(process.argv[i], 'utf8'));
+
+    for (let target in build_meta) {
+        // Target defined by target.name in docker-bake.hcl. Example:
+        // postgres-17_4-arm64-noble
+        const parts = target.split("-")
+        const pgv = parts[1].replace("_", "."), arch = parts[2], os = parts[3]
+        const [major] = pgv.split(".")
+        const key = `${ pgv }-${ os }`
+        const digest = build_meta[target]["containerimage.digest"]
+
+        if (!images.hasOwnProperty(key)) {
+            // Haven't seen this target, save its digest.
+            images[key] = digest
+            continue
+        }
+
+        const image = `${ process.env.REGISTRY }/postgres`
+
+        // Assemble the image names with their SHAs.
+        const shas = `${ image }@${ digest } ${ image }@${ images[key] }`
+
+        // Assemble the tags. They should be the same as those defined in
+        // docker-back.hcl's tags() function.
+        const tags = [
+            `${ image }:${ major }-${ os }`,
+            `${ image }:${ pgv }-${ os }`,
+            `${ image }:${ pgv }-${ os }-${ now }`,
+        ]
+        if (os == LATEST_OS) {
+            tags.push(
+                `${ image }:${ pgv }`,
+                `${ image }:${ major }`,
+            )
+            if (major == LATEST_PG) tags.push(`${ image }:latest`)
+        }
+
+        // Create the image manifest.
+        exec(`docker buildx imagetools create -t ${ tags.join(" -t ") } ${ shas }`)
+        delete images[key]
+    }
+}
+
+if (!isEmpty(images)) {
+    console.error(`Missed some images:\n  ${ Object.keys(images).join("\n  ") }`)
+    process.exit(1)
+}
+
+function exec(cmd) {
+    const exec = require("child_process").exec;
+    exec(cmd,  (err, stdout, stderr) => {
+        if (stdout != "") console.log(stdout)
+        if (err) {
+            console.error(err.message)
+            process.exit(2)
+        }
+        if (stderr != "") console.error(stderr)
+    })
+}
+
+function isEmpty(obj) {
+    for (var prop in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, prop)) return false;
+    }
+    return true
+}


### PR DESCRIPTION
Create a new base image named `postgres` with a single `Dockerfile` and a `docker-bake.hcl` file to script building it for various Postgres and OS versions. This greatly simplifies things, as there is no need for multiple `Dockerfile`s and base images. It's all managed via a single call to `docker buildx bake` and various variables, with support for:

*   PostgreSQL 14-17
*   Ubuntu Noble and Jammy
*   ARM64 and AMD64

The tags include the Postgres version, OS name, and timestamp e.g.,

*   `postgres:17-jammy`
*   `postgres:17.4-jammy`
*   `postgres:17.4-jammy-202503041708`

Images built on the latest OS also have the tags:

*   `postgres:17`
*   `postgres:17.4`

And an image built on the latest Postgres includes the tag:

*   `postgres:latest`

The new workflow, `.github/workflows/bake.yaml`, takes advantage of the recently-introduced `ubuntu-24.04-arm` GitHub worker to efficiently build images for AMD64 and ARM64 in its matrixed jobs. It sets the appropriate variables for each invocation of `docker buildx bake` to build for each supported architecture, OS, and Postgres version. This parallelized build process with native hardware provides the most shortest possible build times.

To create multi-platform images, the `build` job pushes only SHAs, no tags, records the `bake` metadata in files, and the `manifest` job passes those files to `manifest.js`. This script assembles the necessary parts to replicate the `docker-bake.hcl` tags to create and push multi-platform manifests for each OS and Postgres version combination.

In general all version updates should be configured in the `docker-bake.hcl` and `manifest.js` files, including the PostgreSQL versions and Ubuntu versions and & releases.

The `bake.yaml` workflow runs on every push, but only pushes a release on the `main` branch. A schedule configuration triggers new builds on Mondays, so that we're always up-to-date.

The new image diverges from the old images in a number of significant ways, some of which have implications for Trunk and the Tembo operator. These changes were driven primarily by two goals: to better organize persistent files on Tembo Cloud, and to transparently work in a plain Docker container, as a CNPG cluster, and in Tembo Cloud. To that first goal, the image now contains a simple `docker-entrypoint.sh` that creates and starts a cluster, which should simplify testing in many cases.

Other Details:

*   The image is about 1G in size, a quarter the size of the old slim image. This is mainly due to compiling Postgres in one stage with all the build tools (compiler, etc.), and copying the binaries to a separate stage that includes none of the build-time dependencies. This makes the image safer, as well.
*   The final image consists of a single layer. This reduces the size of the image, as well, and reduces the overhead on the Kubernetes cluster. This is done by copying all the files from the build stage onto a `FROM scratch` stage.
*   The image includes no additional extensions or Apt packages or compiled dependencies that extensions might require. The intention is that they will be installed by the operator into the persistent volume.
*   Postgres is installed into `/usr/lib/postgresql` instead of `/usr/lib/postgresql/$PG_MAJOR`. PGDG includes the version in the path so that one can install and run multiple versions at once, but we do not need that.
*   There is a new directory for the persistent volume, `/var/lib/postgresql/tembo`. The old directory, `/var/lib/postgresql/data`, still exists. This change allows the image to work with both Tembo Cloud and stock CNPG. However it will require logic in the Tembo operator to mount the proper directory.
*   The package directory (`pg_config --pkglibdir`) has moved from /var/lib/postgresql/data/tembo/$PG_MAJOR/lib` to `/usr/lib/postgresql/lib`, as the DSOs from core should always be for the current version, and don't need to persist. The location under `tembo`, which is the shared directory (`pg_config --sharedir`) was funky, as the shared directory is for architecturally-neutral files, and shared modules are not that.
*   A new directory, `/var/lib/postgresql/tembo/$PG_MAJOR/lib`, is intended for shared libraries from extensions. We will need to add this directory to `dynamic_library_path` and update `trunk` to install shared modules there instead of `pg_config --pkglibdir`.
*   Another new directory, `/var/lib/postgresql/tembo/$OS_NAME/lib`, is intended for system shared object libraries that dependencies require. We will need to build Apt packages to install them there.
*   A third new directory, `/var/lib/postgresql/tembo/$OS_NAME/etc`, contains the `ld.so.cache` file generated by `ldconfig`. Its canonical location, `/etc/ld.so.cache`, is a symlink to the new location. This will allow new shared files to be installed and `lcconfig` to update a persistent cache.
*   The `--datarootdir`, which is also used for what becomes `pg_config --sharedir`, now points to `/var/lib/postgresql/tembo/share`, and its contents are hard-linked in `/tmp/pg_sharedir`. The Tembo operator should be updated to always copy the latest data from `/tmp/pg_sharedir` on pod init, without wiping out any files or directories it doesn't copy.
*   The `postgres` user's home directory is now `/var/lib/postgresql`, and that is also the working directory, so `exec`ing into a shell starts in that directory, which has the `data` (for the default and CNPG clusters) and `tembo` (for Tembo Cloud) subdirectories immediately available.