### PR TITLE
Add custom `rpath` and `postgres-dev` image

### DIFF
--- a/.github/workflows/bake.yaml
+++ b/.github/workflows/bake.yaml
@@ -60,13 +60,8 @@ jobs:
           pg: ${{ matrix.pg }}
         with:
           pull: true
-          # Set to build only the current arch, to push only SHAs, and no
-          # tags. Required for the manifest step to build and push a
-          # multi-platform manifest.
-          set: |
-            *.platform=linux/${{ matrix.arch[1] }}
-            *.output=type=${{ github.ref_name == 'main' && 'image,push-by-digest=true,push=true' || 'cacheonly' }}
-            *.tags=quay.io/tembo/postgres
+          # Push only on main.
+          set: ${{ github.ref_name == 'main' && '' || '*.output=type=cacheonly' }}
       - name: Save Metadata
         run: echo '${{ steps.build.outputs.metadata }}' > build-${{ matrix.arch[1] }}-${{ matrix.os[1] }}-${{ matrix.pg }}.json
       - name: Upload Metadata

--- a/README.md
+++ b/README.md
@@ -34,9 +34,14 @@ Ubuntu Noble (24.04) and Jimmy (22.04) for the ARM64 and AMD64 processors.
 
 *   Automatically rebuilt every Monday to ensure they remain up-to-date.
 
+*   In addition to `quay.io/tembo/postgres`, als builds
+    `quay.io/tembo/postgres-dev`, which contains the tooling to compile
+    extensions, including compilers, Git, Curl, and more.
+
 ## Building
 
-The easiest way to build and load a single image into Docker is:
+The easiest way to build and load the `postgres` and `postgres-dev` images
+into Docker is:
 
 ```sh
 arch="$(uname -m)" pg_version=17.4 docker buildx bake --load


### PR DESCRIPTION
Compile Postgres with a custom `rpath` that points not only to its main lib directory, but also the lib directories under
`/var/lib/postgresql/tembo`. This will allow Postgres and extensions compiled against this image to find third-party libraries in those directories on the persistent volume without any changes to the immutable parts of the image. In other words, no need for `ldconfig`.

As a consequence, remove the funky ld cache symlinking from the image, as well as the ld configurations for the Postgres and Tembo lib directories, as they're no longer needed.

In order to take advantage of this feature in future extension builds, add a second image, `postgres-dev`, which contains `build-essential`, `git`, `curl` and other tools for building extensions.

Update `manifest.json` to handle parse image names as part of the target names.

In order to transparently support both the `postgres` and `postgres-dev` images in `docker-bake.hcl`, remove all tagging and leave it to `manifest.json`. This allows a single target with a matrix with the target names, and a custom function to generate appropriate metadata field values.