### PR TITLE
Use data dir and remove `/tmp/pg_*` caches

### DIFF
--- a/CONTAINER_README.md
+++ b/CONTAINER_README.md
@@ -6,29 +6,20 @@ live here in `/var/lib/postgresql`. Here's a description of subdirectories and
 their purposes:
 
 *   `data`: The directory in which the Docker entrypoint initializes
-    a cluster and which [CloudNativePG] mounts as a persistent volume.
+    a cluster and which [Tembo Cloud] mounts as a persistent volume.
 *   `data/pgdata`: The data directory initialized by the Docker entrypoint and
-    [CloudNativePG].
-*   `tembo`: The directory that [Tembo Cloud] mounts as the persistent volume
-    for the database and extensions.
-*   `tembo/pgdata`: The data directory initialized by [Tembo Cloud].
-*   `tembo/lib`: A directory for shared library files required by extensions.
-*   `tembo/mod`: A directory for extension module library files.
-*   `tembo/share`: The directory for architecture-independent support files
+    [Tembo Cloud].
+*   `data/lib`: A directory for shared library files required by extensions.
+*   `data/mod`: A directory for extension module library files.
+*   `data/share`: The directory for architecture-independent support files
     used by Postgres. This is the directory used by `pg_config --sharedir` to
-    install non-binary extension files. Its files are copied from
-    `/tmp/pg_sharedir` when the Tembo operator initializes the volume.
-
+    install non-binary extension files.
 
 Other useful locations around the system:
 
 *   `/usr/lib/postgresql`: The base directory for Postgres itself.
 *   `/usr/local/bin/docker-entrypoint.sh`: The docker entrypoint script, which
     initializes and starts a Postgres cluster in `/var/lib/postgresql/data/pgdata`.
-*   `/etc/ld.so.conf.d/postgres.conf`: Configures the library loader to look
-    for library files in the Postgres library directory (`pg_config --libdir`).
-*   `/etc/ld.so.conf.d/tembo.conf`: Configures the library loader to look
-    for library files in `/var/lib/postgresql/tembo/${OS_NAME}/lib`.
 
   [CloudNativePG]: https://cloudnative-pg.io
   [Tembo Cloud]: https://tembo.io/docs/product/cloud/overview "Tembo Cloud Overview"

--- a/geo-cnpg/Dockerfile
+++ b/geo-cnpg/Dockerfile
@@ -45,11 +45,7 @@ RUN /usr/bin/trunk install postgis --version 3.5.0 \
     && make -C MobilityDB/build -j8 install \
     && rm -rf MobilityDB
 
-# cache all extensions
-RUN set -eux; \
-    ldconfig; \
-    cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
-    cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
+RUN ldconfig
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 ENV XDG_CACHE_HOME=/var/lib/postgresql/data/tembo/.cache

--- a/ml-cnpg/Dockerfile
+++ b/ml-cnpg/Dockerfile
@@ -19,11 +19,6 @@ RUN set -eux; \
   trunk install jsonb_plpython3u; \
   trunk install ltree_plpython3u;
 
-# cache all extensions
-RUN set -eux; \
-      cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
-      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir;
-
 # Revert the postgres user to id 26
 RUN usermod -u 26 postgres
 USER 26

--- a/standard-cnpg/Dockerfile
+++ b/standard-cnpg/Dockerfile
@@ -122,11 +122,7 @@ RUN set -eux; \
     ldconfig; \
     # Install auto_explain and pg_stat_statements.
     /usr/bin/trunk install auto_explain; \
-    /usr/bin/trunk install pg_stat_statements; \
-    # cache pg_stat_statements and auto_explain and pg_stat_kcache to temp directory
-    mkdir /tmp/pg_pkglibdir /tmp/pg_sharedir; \
-    cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
-    cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir
+    /usr/bin/trunk install pg_stat_statements;
 
 # Revert the postgres user to id 26
 RUN usermod -u 26 postgres

--- a/tembo-pg-cnpg/Dockerfile
+++ b/tembo-pg-cnpg/Dockerfile
@@ -39,13 +39,6 @@ RUN trunk install pg_stat_statements
 # Install auto_explain
 RUN trunk install auto_explain
 
-# cache pg_stat_statements and auto_explain and pg_stat_kcache to temp directory
-RUN set -eux; \
-	  mkdir /tmp/pg_pkglibdir; \
-	  mkdir /tmp/pg_sharedir; \
-      cp -r $(pg_config --pkglibdir)/* /tmp/pg_pkglibdir; \
-      cp -r $(pg_config --sharedir)/* /tmp/pg_sharedir
-
 # Revert the postgres user to id 26
 RUN usermod -u 26 postgres
 USER 26


### PR DESCRIPTION
Go back to using `/var/lib/postgresql/data` instead of `/var/lib/postgresql/tembo` because, although it made it compatible with stock CNPG, it was incompatible with Tembo Cloud, which also relies on CNPG, so it would never be mounted. It means the image will no longe be compatible with stock CNPG, sadly, because
`/var/lib/postgresql/data/share` is still the shared directory, and CNPG will wipe it out when it mounts the `pgdata` volume at `/var/lib/postgresql/data`.

Also remove the copying of the contents of `/var/lib/postgresql/data` to `/tmp/pg_sharedir` and `/tmp/pg_pkglibdir` from all images. As of tembo-io/tembo#1185, the init pod now copies files directly from `/var/lib/postgresql/data`.