### PR TITLE
Add /tmp/sync-volume.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,9 +125,10 @@ RUN set -ex; \
 	useradd -r -g postgres --uid=26 --home-dir=${PG_HOME} --shell=/bin/bash postgres && \
     chown -R postgres:postgres ${PG_HOME};
 
-# Add the README and entrypoint script.
+# Add the README, entrypoint script, and sync script.
 COPY CONTAINER_README.md "${PG_HOME}/README.md"
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY sync-volume.sh /tmp/
 
 ##############################################################################
 # Build the postgres-dev image as a single layer.
@@ -176,9 +177,10 @@ RUN set -xe; \
     mkdir -p "${TEMBO_LD_LIB_DIR}" "${TEMBO_PG_MOD_DIR}"; \
     rm -rf /var/lib/apt/lists/* /var/cache/* /var/log/*;
 
-# Add the README and entrypoint script.
+# Add the README, entrypoint script, and sync script.
 COPY CONTAINER_README.md "${PG_HOME}/README.md"
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY sync-volume.sh /tmp/
 
 # Create the Postgres user and set its uid to what CNPG expects.
 RUN groupadd -r postgres --gid=999 && \

--- a/sync-volume.sh
+++ b/sync-volume.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+# CNPG mounts this persistent volume to store data. Tembo also stores
+# extension files and dependent libraries here. On Pod initialization, Tembo
+# mounts the persistent volume to another location and passes it to this
+# script. The script copies the data the image put into the src into the dst
+# directory, so that when CNPG mounts the volume all the data from this Docker
+# image will be present in the persistent volume.
+
+src=/var/lib/postgresql/data
+
+migrate() {
+    # Migrate libraries, modules, and shared files to their new locations.
+    pushd "${1}"
+    pgv="$(pg_config --version | perl -ne '/(\d+)/ && print $1')"
+    if [ -d "tembo/$pgv/lib" ]; then
+        # In old Tembo images, all Postgres libdir and pkglibdir files were
+        # here. Remove the files burned into the image.
+        if [ -d "tembo/$pgv/lib/bitcode" ]; then
+            for file in /usr/lib/postgresql/lib/bitcode/*; do
+                rm -rf "tembo/$pgv/lib/bitcode/$(basename "$file")"
+            done
+        fi
+        for file in /usr/lib/postgresql/lib/*; do
+            bn="$(basename "$file")"
+            if [ "$bn" != "bitcode" ]; then
+                rm -rf "tembo/$pgv/lib/$bn"
+            fi
+        done
+        # Move likely dependent lib files to lib.
+        mkdir -p lib
+        mv "tembo/$pgv/lib/lib"* lib/
+        # Move the remaining files, mostly extension modules, to mod.
+        mv "tembo/$pgv/lib" mod
+        rmdir "tembo/$pgv"
+    fi
+
+    # The rest of the tembo directory is sharedir; rename it.
+    mv tembo share
+    popd
+}
+
+main() {
+    dst="${1-/var/lib/postgresql/init}"
+    # If the tembo directory managed by old images exists, migrate its files.
+    if [ -d "$dst/tembo" ]; then migrate "$dst"; fi;
+    # Update core modules and extensions on the volume.
+    cp -p --recursive --update "$src/"* "$dst/"
+}
+
+main "$@"


### PR DESCRIPTION
This script will be executed by the `initContainer` that Tembo Cloud injects to run prior to CNPG's `initdb` container. Its main task is to sync files from `/var/lib/postgresql/data` to a destination passed to it, which will be the volume that will mask `/var/lib/postgresql/data` in the CNPG containers. This ensures that all the files specific to this version of PostgreSQL are up-to-date.

But its secondary task, defined in the `migrate()` function, is to migrate files from the locations defined by the old Tembo images. It deletes files and directories that are part of the PostgreSQL `--libdir`, which are now included in this image, rather than stored on the volume. But it leaves behind extension files, bitcode, and dependent library files that are not part of core `--libdir`. This will allow exiting images to transparently upgrade to the new image without loss of functionality (although additional library dependencies still need to be worked out).